### PR TITLE
Fix purchase module data fetching issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,10 @@ assets/images/upload/
 modules/*/uploads/
 *.log
 
-# Ignore temporary files
+# Ignore temporary files and backups
 *.tmp
 *.temp
+*.zip
 .DS_Store
 Thumbs.db
 

--- a/modules/purchase/add.php
+++ b/modules/purchase/add.php
@@ -338,12 +338,18 @@ $('#jci_number_search').on('change', function() {
                                     }
                                     console.log('=== END PURCHASE DATA DEBUG ===');
                                     
-                                    var existingItems = purchaseData.has_purchase ? purchaseData.purchase_items : [];
-                                    // Use enhanced render function
-                                    if (typeof renderEnhancedBomTable === 'function') {
-                                        renderEnhancedBomTable(jobCards, bomItemsData, existingItems);
+                                    // Use working fix table creation if available
+                                    if (purchaseData.has_purchase && purchaseData.purchase_items && typeof window.createPurchaseTable === 'function') {
+                                        console.log('=== USING WORKING FIX TABLE CREATION ===');
+                                        window.createPurchaseTable(purchaseData.purchase_items);
                                     } else {
-                                        renderBomTable(jobCards, bomItemsData, existingItems);
+                                        var existingItems = purchaseData.has_purchase ? purchaseData.purchase_items : [];
+                                        // Use enhanced render function
+                                        if (typeof renderEnhancedBomTable === 'function') {
+                                            renderEnhancedBomTable(jobCards, bomItemsData, existingItems);
+                                        } else {
+                                            renderBomTable(jobCards, bomItemsData, existingItems);
+                                        }
                                     }
                                 },
                                 error: function() {


### PR DESCRIPTION
- Fixed user access control in purchase/index.php to allow accountsadmin to view all purchase records
- Removed restrictive filtering that was hiding records with NULL created_by values
- Updated purchase/add.php to improve data rendering logic
- Added .zip files to .gitignore to exclude backup files

Issue: Data was saving properly in database but not displaying due to overly restrictive user filtering
Solution: Allow both superadmin and accountsadmin to view all purchase records regardless of created_by field